### PR TITLE
EGGD - BRI Hold Fix

### DIFF
--- a/Include/egxx/egtt/stars/EGGP.str
+++ b/Include/egxx/egtt/stars/EGGP.str
@@ -3,7 +3,7 @@
 /// Developed by the IVAO XU community ///
 //////////////////////////////////////////
 
-EGGP;09:27;GASKO1L;
+EGGP;09:27;GASKO1L;GASKO;GASKO;
 GASKO;GASKO;FL170;
 RIBEL;RIBEL;
 CROFT;CROFT;


### PR DESCRIPTION
Issue displaying BRI Hold with GASKO1L arrival from EGGP with a beeline for the Equator/Greenwich point. Fixed
![image](https://github.com/IVAO-XU/EG-Sector-File/assets/97858915/ed503e42-80c7-4d51-9851-6f910d522055)
